### PR TITLE
Reject promise on request/response error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ NPM package here www.npmjs.com/package/visionect-api
 ## Prerequisite
 
 You'll need an instance of Visionect Server to use it 
-https://docs.visionect.com/VisionectPackages.html
+https://docs.visionect.com/VisionectSoftwareSuite/Installation.html
 When your server is running, go to your backend, select the user tab, and add a new apiKey.
 
 ## Install the package


### PR DESCRIPTION
Currently, if there is an error when sending api request or receiving the response, returned `Promise` will never be fulfilled. 

This pull request addresses this issue by attaching to error events from request/response objects and reject the Promise. If request times out, then an `ETIMEDOUT` error will be emitted and request manually aborted.

Minor: fixed broken link to VSS installation instructions in `README`.